### PR TITLE
Adding `preprocess_camxmet` function

### DIFF
--- a/aqmsp_data/preprocessing.py
+++ b/aqmsp_data/preprocessing.py
@@ -252,7 +252,7 @@ def preprocess_raw_camx_output():
 
 def preprocess_camx_met(camx_met_file: str, verbose: bool = False) -> xr.Dataset:
     assert camx_met_file.endswith(".nc"), f"File '{camx_met_file}' must be a netcdf file"
-    assert camx_met_file.startswith("camxmet2d.delhi"), f"File '{camx_met_file}' must start with 'camxmet2d.delhi'"
+    #assert camx_met_file.startswith("camxmet2d.delhi"), f"File '{camx_met_file}' must start with 'camxmet2d.delhi.2023'"
     camx_met = xr.open_dataset(camx_met_file)
     xorig = camx_met.XORIG
     yorig = camx_met.YORIG

--- a/aqmsp_data/preprocessing.py
+++ b/aqmsp_data/preprocessing.py
@@ -7,11 +7,12 @@ from aqmsp.path_utils import get_repo_root
 import aqmsp_data.constants as C
 from aqmsp.debug_utils import set_verbose, verbose_print
 from time import time
+
 from typing import Union
 
 
 def preprocess_raw_cpcb(path: str, stations_ds_path: str) -> Union[xr.Dataset, None]:
-    """Preprocess raw CPCB data and return an xr dataset.
+    """Preprocess raw CPCB data and return an xarray dataset.
 
     Args:
         path (str): Path to the raw CPCB data file.
@@ -81,7 +82,7 @@ def preprocess_raw_cpcb(path: str, stations_ds_path: str) -> Union[xr.Dataset, N
     # convert data to numeric
     df = df.apply(pd.to_numeric)
 
-    # convert to xr dataset
+    # convert to xarray dataset
     ds = df.to_xarray()
 
     # assign latitudes and longitudes
@@ -126,7 +127,7 @@ def split_and_save_cpcb(ds: xr.Dataset):
     if ds is None:
         verbose_print("ds is None. Skipping.")
         return None
-    assert isinstance(ds, xr.Dataset), "ds must be an xr dataset"
+    assert isinstance(ds, xr.Dataset), "ds must be an xarray dataset"
     root = get_repo_root(__file__)
     station = ds.station.values.item()
     station = station.replace(" ", "_")
@@ -247,6 +248,7 @@ def assert_correct_variable(variables):
 
 def preprocess_raw_camx_output():
     pass
+
 
 def preprocess_camx_met(camx_met_file: str, verbose: bool = False) -> xr.Dataset:
     assert camx_met_file.endswith(".nc"), f"File '{camx_met_file}' must be a netcdf file"

--- a/aqmsp_data/preprocessing.py
+++ b/aqmsp_data/preprocessing.py
@@ -83,7 +83,7 @@ def preprocess_raw_cpcb(path: str, stations_ds_path: str) -> Union[xr.Dataset, N
     df = df.apply(pd.to_numeric)
 
     # convert to xr dataset
-    ds = df.to_xr()
+    ds = df.to_xarray()
 
     # assign latitudes and longitudes
     ds = ds.assign_coords(

--- a/aqmsp_data/preprocessing.py
+++ b/aqmsp_data/preprocessing.py
@@ -258,7 +258,7 @@ def preprocess_camx_met(camx_met_file: str, verbose: bool = False) -> xr.Dataset
     yorig = camx_met.YORIG
     longitude = xorig + (camx_met.COL.values - 1) * 0.01
     latitude = yorig + (camx_met.ROW.values - 1) * 0.01
-    camx_met = camx_met.rename({'ROW': 'latitude', 'COL': 'longitude','TSEP':'time'})
+    camx_met = camx_met.rename({'ROW': 'latitude', 'COL': 'longitude','TSTEP':'time'})
     camx_met['latitude'], camx_met['longitude'] = latitude, longitude
     temp_datasets = []
     for lag in range(4):

--- a/aqmsp_data/preprocessing.py
+++ b/aqmsp_data/preprocessing.py
@@ -252,7 +252,7 @@ def preprocess_raw_camx_output():
 
 def preprocess_camx_met(camx_met_file: str, verbose: bool = False) -> xr.Dataset:
     assert camx_met_file.endswith(".nc"), f"File '{camx_met_file}' must be a netcdf file"
-    assert camx_met_file.startswith("camxmet2d.delhi.2023"), f"File '{camx_met_file}' must start with 'camxmet2d.delhi.2023'"
+    assert camx_met_file.startswith("camxmet2d.delhi"), f"File '{camx_met_file}' must start with 'camxmet2d.delhi'"
     camx_met = xr.open_dataset(camx_met_file)
     xorig = camx_met.XORIG
     yorig = camx_met.YORIG

--- a/aqmsp_data/preprocessing.py
+++ b/aqmsp_data/preprocessing.py
@@ -275,7 +275,7 @@ def preprocess_camx_met(camx_met_file: str, verbose: bool = False) -> xr.Dataset
         if verbose:
             print(f"Preprocessed CAMx meteorological data for lag {lag}:")
             print(data_temp)
-    reshaped_camx = xr.concat(temp_datasets, pd.Index(range(4), name='lag')).sel(LAY=0, VAR=0)
+    reshaped_camx = xr.concat(temp_datasets, pd.Index(range(4), name='lag')).sel(LAY=0, VAR=0).drop('TFLAG')
     return reshaped_camx
 
 if __name__ == "__main__":

--- a/aqmsp_data/preprocessing.py
+++ b/aqmsp_data/preprocessing.py
@@ -262,7 +262,7 @@ def preprocess_camx_met(camx_met_file: str, verbose: bool = False) -> xr.Dataset
     camx_met['latitude'], camx_met['longitude'] = latitude, longitude
     temp_datasets = []
     for lag in range(4):
-        data_temp = camx_met.sel(TSTEP=slice(lag * 24, 24 * (lag + 1)))
+        data_temp = camx_met.sel(time=slice(lag * 24, 24 * (lag + 1)))
         date_str = camx_met_file.split('.')[-3]
         timesteps = data_temp.dims['time']
         start_time = pd.Timestamp(date_str + ' 00:00:00')

--- a/tests/.gitattributes
+++ b/tests/.gitattributes
@@ -1,0 +1,1 @@
+.nc filter=lfs diff=lfs merge=lfs -text

--- a/tests/.gitattributes
+++ b/tests/.gitattributes
@@ -1,1 +1,0 @@
-.nc filter=lfs diff=lfs merge=lfs -text

--- a/tests/test_camx.py
+++ b/tests/test_camx.py
@@ -2,7 +2,7 @@ from aqmsp_data.preprocessing import preprocess_camx_met
 import xarray as xr
 
 def test_preprocess_raw_camx():
-    path = "camxmet2d.delhi.20231018.96hours.nc"
+    path = "/tests/camxmet2d.delhi.20231018.96hours.nc"
     ds = preprocess_camx_met(path,verbose=True)
     print(ds)
     assert isinstance(ds, xr.Dataset)

--- a/tests/test_camx.py
+++ b/tests/test_camx.py
@@ -2,7 +2,7 @@ from aqmsp_data.preprocessing import preprocess_camx_met
 import xarray as xr
 
 def test_preprocess_raw_camx():
-    path = "C:/Users/tkrsh/Downloads/camxmet2d.delhi.2023/camxmet2d.delhi.20231018.96hours.nc"
+    path = "camxmet2d.delhi.20231018.96hours.nc"
     ds = preprocess_camx_met(path,verbose=True)
     print(ds)
     assert isinstance(ds, xr.Dataset)

--- a/tests/test_camx.py
+++ b/tests/test_camx.py
@@ -1,9 +1,9 @@
-from aqmsp_data.preprocessing import preprocess_camx_met
+from aqmsp_data import preprocessing
 import xarray as xr
 
 def test_preprocess_raw_camx():
     path = "tests/camxmet2d.delhi.20231018.96hours.nc"
-    ds = preprocess_camx_met(path,verbose=True)
+    ds = preprocessing.preprocess_camx_met(path,verbose=True)
     print(ds)
     assert isinstance(ds, xr.Dataset)
     return ds

--- a/tests/test_camx.py
+++ b/tests/test_camx.py
@@ -1,10 +1,12 @@
 from aqmsp_data.preprocessing import preprocess_camx_met
 import xarray as xr
-from aqmsp.debug_utils import set_verbose, verbose_print
 
-def test_preprocess_raw_cpcb():
-    path = "/home/utkarsh.mittal/camxmet2d.delhi.2023/camxmet2d.delhi.20230717.96hours.nc"
+def test_preprocess_raw_camx():
+    path = "C:/Users/tkrsh/Downloads/camxmet2d.delhi.2023/camxmet2d.delhi.20231018.96hours.nc"
     ds = preprocess_camx_met(path,verbose=True)
     print(ds)
     assert isinstance(ds, xr.Dataset)
     return ds
+
+if __name__ == "__main__":
+    test_preprocess_raw_camx()

--- a/tests/test_camx.py
+++ b/tests/test_camx.py
@@ -2,7 +2,7 @@ from aqmsp_data.preprocessing import preprocess_camx_met
 import xarray as xr
 
 def test_preprocess_raw_camx():
-    path = "/tests/camxmet2d.delhi.20231018.96hours.nc"
+    path = "tests/camxmet2d.delhi.20231018.96hours.nc"
     ds = preprocess_camx_met(path,verbose=True)
     print(ds)
     assert isinstance(ds, xr.Dataset)

--- a/tests/test_camx.py
+++ b/tests/test_camx.py
@@ -1,0 +1,10 @@
+from aqmsp_data.preprocessing import preprocess_camx_met
+import xarray as xr
+from aqmsp.debug_utils import set_verbose, verbose_print
+
+def test_preprocess_raw_cpcb():
+    path = "/home/utkarsh.mittal/camxmet2d.delhi.2023/camxmet2d.delhi.20230717.96hours.nc"
+    ds = preprocess_camx_met(path,verbose=True)
+    print(ds)
+    assert isinstance(ds, xr.Dataset)
+    return ds


### PR DESCRIPTION
This PR addresses #3.

## Examples

@UtkarshMitta Please add some examples here.

One exmple of how preprocessing works:

This is `camxmet2d.delhi.2023/camxmet2d.delhi.20230717.96hours.nc`
```
<xarray.Dataset>
Dimensions:     (TSTEP: 96, VAR: 14, DATE-TIME: 2, LAY: 1, ROW: 80, COL: 80)
Dimensions without coordinates: TSTEP, VAR, DATE-TIME, LAY, ROW, COL
Data variables: (12/15)
    TFLAG       (TSTEP, VAR, DATE-TIME) int32 ...
    TSURF_K     (TSTEP, LAY, ROW, COL) float32 ...
    SNOWEW_M    (TSTEP, LAY, ROW, COL) float32 ...
    SNOWAGE_HR  (TSTEP, LAY, ROW, COL) float32 ...
    PRATE_MMpH  (TSTEP, LAY, ROW, COL) float32 ...
    CLOUD_OD    (TSTEP, LAY, ROW, COL) float32 ...
    ...          ...
    SWSFC_WpM2  (TSTEP, LAY, ROW, COL) float32 ...
    SOLM_M3pM3  (TSTEP, LAY, ROW, COL) float32 ...
    CLDTOP_KM   (TSTEP, LAY, ROW, COL) float32 ...
    CAPE        (TSTEP, LAY, ROW, COL) float32 ...
    PBL_WRF_M   (TSTEP, LAY, ROW, COL) float32 ...
    PBL_YSU_M   (TSTEP, LAY, ROW, COL) float32 ...
Attributes: (12/33)
    IOAPI_VERSION:  $Id: @(#) ioapi library version 3.0 $                    ...
    EXEC_ID:        ????????????????                                         ...
    FTYPE:          1
    CDATE:          2023198
    CTIME:          73941
    WDATE:          2023198
    ...             ...
    VGLVLS:         [0. 0.]
    GDNAM:          ????????????????
    UPNAM:          CAMx2IOAPI      
    VAR-LIST:       TSURF_K         SNOWEW_M        SNOWAGE_HR      PRATE_MMp...
    FILEDESC:       I/O API formatted CAMx AVRG output                       ...
    HISTORY:        
```

As we see, 96 timestamps with `ROW` and `COL` being integers:
```
<xarray.DataArray 'ROW' (ROW: 80)>
array([ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17,
       18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35,
       36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53,
       54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71,
       72, 73, 74, 75, 76, 77, 78, 79], dtype=int64)
Dimensions without coordinates: ROW 
<xarray.DataArray 'COL' (COL: 80)>
array([ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17,
       18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35,
       36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53,
       54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71,
       72, 73, 74, 75, 76, 77, 78, 79], dtype=int64)
Dimensions without coordinates: COL
```

The function converts 96 timestamps to 24 timestamps using new dimension `lag` and removes the dimensions that are not being used to access any value
```
xarray.Dataset>
Dimensions:     (lag: 4, time: 24, DATE-TIME: 2, latitude: 80, longitude: 80)
Coordinates:
  * latitude    (latitude) float64 28.19 28.2 28.21 28.22 ... 28.96 28.97 28.98
  * longitude   (longitude) float64 76.84 76.85 76.86 ... 77.61 77.62 77.63
  * time        (time) datetime64[ns] 2023-07-17T05:30:00 ... 2023-07-18T04:3...
  * lag         (lag) int64 0 1 2 3
Dimensions without coordinates: DATE-TIME
Data variables: (12/15)
    TFLAG       (lag, time, DATE-TIME) int32 2023198 0 ... 2023201 230000
    TSURF_K     (lag, time, latitude, longitude) float32 302.3 302.3 ... 301.2
    SNOWEW_M    (lag, time, latitude, longitude) float32 0.0 0.0 0.0 ... 0.0 0.0
    SNOWAGE_HR  (lag, time, latitude, longitude) float32 0.0 0.0 0.0 ... 0.0 0.0
    PRATE_MMpH  (lag, time, latitude, longitude) float32 0.0 0.0 0.0 ... 0.0 0.0
    CLOUD_OD    (lag, time, latitude, longitude) float32 62.24 61.67 ... 36.78
    ...          ...
    SWSFC_WpM2  (lag, time, latitude, longitude) float32 0.0 0.0 0.0 ... 0.0 0.0
    SOLM_M3pM3  (lag, time, latitude, longitude) float32 0.3131 ... 0.3292
    CLDTOP_KM   (lag, time, latitude, longitude) float32 0.0 0.0 0.0 ... 0.0 0.0
    CAPE        (lag, time, latitude, longitude) float32 0.0 0.0 0.0 ... 0.0 0.0
    PBL_WRF_M   (lag, time, latitude, longitude) float32 17.21 17.21 ... 120.0
    PBL_YSU_M   (lag, time, latitude, longitude) float32 17.21 17.21 ... 94.71
Attributes: (12/33)
    IOAPI_VERSION:  $Id: @(#) ioapi library version 3.0 $                    ...
    EXEC_ID:        ????????????????                                         ...
    FTYPE:          1
    CDATE:          2023198
    CTIME:          73941
    WDATE:          2023198
    ...             ...
    VGLVLS:         [0. 0.]
    GDNAM:          ????????????????
    UPNAM:          CAMx2IOAPI      
    VAR-LIST:       TSURF_K         SNOWEW_M        SNOWAGE_HR      PRATE_MMp...
    FILEDESC:       I/O API formatted CAMx AVRG output                       ...
    HISTORY:        
```

As we can see above, the `XORIG` and `YORIG` are used to convert the `ROW` and `COL` to `latitude` and `longitude`, having interval of 0.01